### PR TITLE
feat(orders): Create order history page with review placeholder

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/ProductController.php
+++ b/backend/app/Http/Controllers/Api/Admin/ProductController.php
@@ -62,9 +62,12 @@ class ProductController extends Controller
     public function update(StoreProductRequest $request, Product $product)
     {
         $validatedData = $request->validated();
+
+        if ($request->has('is_active')) {
+            $validatedData['is_active'] = $request->input('is_active') === 'true';
+        }
+
         $product->update($validatedData);
-        $product->is_active = $request->input('is_active') === 'true';
-        $product->save();
 
         // Replace images ONLY if new ones are uploaded
         if ($request->hasFile('primary_image') || $request->hasFile('gallery_images')) {

--- a/backend/app/Http/Controllers/Api/OrderController.php
+++ b/backend/app/Http/Controllers/Api/OrderController.php
@@ -14,6 +14,16 @@ use Illuminate\Support\Facades\Validator;
 
 class OrderController extends Controller
 {
+    public function index(Request $request)
+    {
+        $user = Auth::user();
+        $orders = Order::with(['items.product', 'items.review'])
+            ->where('user_id', $user->id)
+            ->latest()
+            ->get();
+        return response()->json(['data' => $orders]);
+    }
+
     public function store(Request $request)
     {
         $validator = Validator::make($request->all(), [
@@ -78,7 +88,7 @@ class OrderController extends Controller
                 return $order;
             });
 
-            return response()->json($order->load('items.product'), 201);
+            return response()->json($order->load(['items.product', 'items.review']), 201);
 
         } catch (\Exception $e) {
             return response()->json(['message' => 'Gagal memproses pesanan: ' . $e->getMessage()], 500);

--- a/backend/app/Http/Controllers/Api/ReviewController.php
+++ b/backend/app/Http/Controllers/Api/ReviewController.php
@@ -1,0 +1,35 @@
+<?php
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Review;
+use App\Models\OrderItem;
+
+class ReviewController extends Controller
+{
+    public function store(Request $request)
+    {
+        $request->validate([
+            'product_id' => 'required|exists:products,id',
+            'order_item_id' => 'required|exists:order_items,id|unique:reviews,order_item_id',
+            'rating' => 'required|integer|min:1|max:5',
+            'comment' => 'nullable|string',
+        ]);
+
+        $orderItem = OrderItem::find($request->order_item_id);
+        if (!$orderItem || $orderItem->order->user_id !== auth()->id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $review = Review::create([
+            'user_id' => auth()->id(),
+            'product_id' => $request->product_id,
+            'order_item_id' => $request->order_item_id,
+            'rating' => $request->rating,
+            'comment' => $request->comment,
+        ]);
+
+        return response()->json(['success' => true, 'data' => $review], 201);
+    }
+}

--- a/backend/app/Models/OrderItem.php
+++ b/backend/app/Models/OrderItem.php
@@ -30,5 +30,12 @@ class OrderItem extends Model
     {
         return $this->belongsTo(Product::class);
     }
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function review() { return $this->hasOne(Review::class); }
 }
 

--- a/backend/app/Models/Product.php
+++ b/backend/app/Models/Product.php
@@ -42,6 +42,11 @@ class Product extends Model
         return $this->belongsTo(Category::class);
     }
 
+        public function reviews()
+        {
+            return $this->hasMany(Review::class);
+        }
+
     public function images(): HasMany
     {
         return $this->hasMany(ProductImage::class);

--- a/backend/app/Models/Review.php
+++ b/backend/app/Models/Review.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Review extends Model
+{
+    use HasFactory;
+    protected $fillable = ['user_id', 'product_id', 'order_item_id', 'rating', 'comment'];
+
+    public function user() { return $this->belongsTo(User::class); }
+    public function product() { return $this->belongsTo(Product::class); }
+    public function orderItem() { return $this->belongsTo(OrderItem::class); }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -46,4 +46,5 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+        public function reviews() { return $this->hasMany(Review::class); }
 }

--- a/backend/database/migrations/2025_09_13_193622_create_product_images_table.php
+++ b/backend/database/migrations/2025_09_13_193622_create_product_images_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('product_images', function (Blueprint $table) {
             $table->id();
             $table->foreignId('product_id')->constrained('products')->onDelete('cascade');
-            $table->string('image_url', 500);
+            $table->string('image_path', 500);
             $table->string('alt_text')->nullable();
             $table->integer('sort_order')->default(0);
         });

--- a/backend/database/migrations/2025_09_28_000000_create_reviews_table.php
+++ b/backend/database/migrations/2025_09_28_000000_create_reviews_table.php
@@ -1,0 +1,31 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('reviews', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('product_id')->constrained()->onDelete('cascade');
+            $table->foreignId('order_item_id')->constrained()->onDelete('cascade')->unique();
+            $table->unsignedTinyInteger('rating'); // 1 to 5
+            $table->text('comment')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('reviews');
+    }
+};

--- a/backend/database/seeders/ProductSeeder.php
+++ b/backend/database/seeders/ProductSeeder.php
@@ -22,74 +22,64 @@ class ProductSeeder extends Seeder
                 'description' => 'Smartphone dengan fitur Pro, kamera canggih dan performa tinggi.',
                 'price' => 7500000,
                 'stock' => 50,
-                'image_url' => 'https://placehold.co/600x400?text=Smartphone+Pro+X',
             ],
             [
                 'name' => 'Laptop UltraBook 14',
                 'description' => 'Laptop ringan dengan performa tinggi dan desain elegan.',
                 'price' => 12500000,
                 'stock' => 30,
-                'image_url' => 'https://placehold.co/600x400?text=Laptop+UltraBook',
             ],
             [
                 'name' => 'Kemeja Formal Pria',
                 'description' => 'Kemeja formal dengan bahan berkualitas untuk acara penting.',
                 'price' => 350000,
                 'stock' => 100,
-                'image_url' => 'https://placehold.co/600x400?text=Kemeja+Formal',
             ],
             [
                 'name' => 'Headphone Wireless X',
                 'description' => 'Headphone dengan teknologi noise-cancelling dan kualitas suara superior.',
                 'price' => 1200000,
                 'stock' => 80,
-                'image_url' => 'https://placehold.co/600x400?text=Headphone+Wireless+X',
             ],
             [
                 'name' => 'Smartwatch V2',
                 'description' => 'Jam tangan pintar dengan berbagai fitur kesehatan dan olahraga.',
                 'price' => 1500000,
                 'stock' => 60,
-                'image_url' => 'https://placehold.co/600x400?text=Smartwatch+V2',
             ],
             [
                 'name' => 'Buku Panduan Python',
                 'description' => 'Buku lengkap untuk mempelajari bahasa pemrograman Python.',
                 'price' => 200000,
                 'stock' => 120,
-                'image_url' => 'https://placehold.co/600x400?text=Buku+Panduan+Python',
             ],
             [
                 'name' => 'Sepatu Lari Pria',
                 'description' => 'Sepatu olahraga ringan dan nyaman untuk berlari.',
                 'price' => 500000,
                 'stock' => 40,
-                'image_url' => 'https://placehold.co/600x400?text=Sepatu+Lari+Pria',
             ],
             [
                 'name' => 'Tas Laptop Premium',
                 'description' => 'Tas laptop dengan bahan premium dan desain elegan.',
                 'price' => 600000,
                 'stock' => 75,
-                'image_url' => 'https://placehold.co/600x400?text=Tas+Laptop+Premium',
             ],
             [
                 'name' => 'Blender Dapur 500W',
                 'description' => 'Blender dengan motor 500W untuk membuat smoothie dan jus segar.',
                 'price' => 400000,
                 'stock' => 150,
-                'image_url' => 'https://placehold.co/600x400?text=Blender+Dapur+500W',
             ],
             [
                 'name' => 'Mixer Elektrik 3 Kecepatan',
                 'description' => 'Mixer elektrik dengan 3 kecepatan untuk membuat kue atau adonan.',
                 'price' => 350000,
                 'stock' => 90,
-                'image_url' => 'https://placehold.co/600x400?text=Mixer+Elektrik+3+Kecepatan',
             ],
         ];
 
-        foreach ($products as $index => $productData) {
+        foreach ($products as $productData) {
             $category = $categories->random();
 
             $slug = Str::slug($productData['name']);
@@ -98,15 +88,17 @@ class ProductSeeder extends Seeder
                 $slug = $slug . '-' . uniqid();
             }
 
-            Product::create([
+            $product = Product::create([
                 'category_id' => $category->id,
-                'name' => $productData['name'],
-                'slug' => $slug,
+                'name'        => $productData['name'],
+                'slug'        => $slug,
                 'description' => $productData['description'],
-                'price' => $productData['price'],
-                'stock' => $productData['stock'],
-                'image_url' => $productData['image_url'],
+                'price'       => $productData['price'],
+                'stock'       => $productData['stock'],
+                'is_active'   => true,
             ]);
+
+            // Tidak membuat gambar jika tidak ada image_path, biarkan frontend fallback ke /no-image.webp
         }
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\ReviewController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\CategoryController;
@@ -33,7 +34,9 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/cart', [CartController::class, 'store']);
     Route::put('/cart-items/{cartItem}', [CartController::class, 'update']);
     Route::delete('/cart-items/{cartItem}', [CartController::class, 'destroy']);
-    
+
+    Route::get('/orders', [OrderController::class, 'index']);
+    Route::post('/reviews', [ReviewController::class, 'store']);
     Route::post('/checkout', [OrderController::class, 'store']);
 });
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import SearchResultsPage from './pages/SearchResultsPage.jsx';
 import ManageProductsPage from './pages/admin/ManageProductsPage.jsx';
 import ManageOrdersPage from './pages/admin/ManageOrdersPage.jsx';
 import CategoryPage from './pages/CategoryPage.jsx';
+import OrderHistoryPage from './pages/OrderHistoryPage.jsx';
 
 function App() {
     return (
@@ -34,7 +35,10 @@ function App() {
                                 path="search"
                                 element={<SearchResultsPage />}
                             />
-                            <Route path="category/:categoryId" element={<CategoryPage />} />
+                            <Route
+                                path="category/:categoryId"
+                                element={<CategoryPage />}
+                            />
                         </Route>
 
                         {/* Ditambahkan: Grup rute baru khusus untuk otentikasi. */}
@@ -57,6 +61,12 @@ function App() {
                                 element={<ManageOrdersPage />}
                             />
                         </Route>
+
+                        {/* User protected route group (contoh, pastikan sudah ada proteksi di AuthProvider) */}
+                        <Route
+                            path="/order-history"
+                            element={<OrderHistoryPage />}
+                        />
                     </Routes>
                 </CartProvider>
             </AuthProvider>

--- a/frontend/src/components/CartItem.jsx
+++ b/frontend/src/components/CartItem.jsx
@@ -14,14 +14,25 @@ function CartItem({
         }
     };
 
-    const imageUrl = item.product.primary_image?.image_path
-        ? `http://localhost:8000/storage/${item.product.primary_image.image_path.replace(
-              'public/',
-              ''
-          )}`
-        : `https://via.placeholder.com/600x600.png?text=${encodeURIComponent(
-              item.product.name || 'Produk'
-          )}`;
+    let imageUrl = '';
+    if (item.product.primary_image && item.product.primary_image.image_path) {
+        const path = item.product.primary_image.image_path;
+        if (path.startsWith('http')) {
+            imageUrl = path;
+        } else if (path.startsWith('/storage')) {
+            imageUrl = `http://localhost:8000${path}`;
+        } else if (path.startsWith('public/')) {
+            imageUrl = `http://localhost:8000/storage/${path.replace(
+                'public/',
+                ''
+            )}`;
+        } else {
+            imageUrl = '/no-image.webp';
+        }
+    } else {
+        imageUrl = '/no-image.webp';
+    }
+
     return (
         <div className="flex items-center border-b py-4">
             <input
@@ -36,9 +47,7 @@ function CartItem({
                 className="w-24 h-24 object-cover rounded-lg mr-4"
                 onError={(e) => {
                     e.currentTarget.onerror = null;
-                    e.currentTarget.src = `https://via.placeholder.com/600x600.png?text=${encodeURIComponent(
-                        item.product.name || 'Produk'
-                    )}`;
+                    e.currentTarget.src = '/no-image.webp';
                 }}
             />
             <div className="flex-grow">

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,7 +1,16 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link, NavLink, useNavigate } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
-import { Menu, X, ShoppingCart, LogOut, LayoutDashboard, ChevronDown } from 'lucide-react';
+import {
+    Menu,
+    X,
+    ShoppingCart,
+    LogOut,
+    LayoutDashboard,
+    ChevronDown,
+    CircleUser,
+    ClipboardClock,
+} from 'lucide-react';
 import { useCart } from '../contexts/CartContext';
 import { useAuth } from '../contexts/AuthContext';
 import SearchBar from './SearchBar';
@@ -10,11 +19,13 @@ import axiosClient from '../api/axiosClient';
 function Navbar() {
     const [isOpen, setIsOpen] = useState(false);
     const [isCategoryOpen, setCategoryOpen] = useState(false);
+    const [isProfileOpen, setProfileOpen] = useState(false);
     const [categories, setCategories] = useState([]);
     const { cartCount } = useCart();
     const { user, logout } = useAuth();
     const navigate = useNavigate();
     const categoryMenuRef = useRef(null);
+    const profileMenuRef = useRef(null);
 
     useEffect(() => {
         const fetchCategories = async () => {
@@ -30,8 +41,17 @@ function Navbar() {
 
     useEffect(() => {
         const handleClickOutside = (event) => {
-            if (categoryMenuRef.current && !categoryMenuRef.current.contains(event.target)) {
+            if (
+                categoryMenuRef.current &&
+                !categoryMenuRef.current.contains(event.target)
+            ) {
                 setCategoryOpen(false);
+            }
+            if (
+                profileMenuRef.current &&
+                !profileMenuRef.current.contains(event.target)
+            ) {
+                setProfileOpen(false);
             }
         };
         document.addEventListener('mousedown', handleClickOutside);
@@ -58,7 +78,7 @@ function Navbar() {
                     </Link>
 
                     <div className="flex-1 flex justify-center items-center px-8">
-                        <div className="relative" ref={categoryMenuRef}> 
+                        <div className="relative" ref={categoryMenuRef}>
                             <button
                                 onClick={() => setCategoryOpen(!isCategoryOpen)}
                                 className="flex items-center bg-gray-100 border border-gray-300 rounded-l-md px-4 py-2 text-gray-700 hover:bg-gray-200 focus:outline-none h-full"
@@ -73,7 +93,9 @@ function Navbar() {
                                             key={category.id}
                                             to={`/category/${category.id}`}
                                             className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                                            onClick={() => setCategoryOpen(false)}
+                                            onClick={() =>
+                                                setCategoryOpen(false)
+                                            }
                                         >
                                             {category.name}
                                         </Link>
@@ -85,7 +107,9 @@ function Navbar() {
                                                 to="/#all-categories"
                                                 smooth
                                                 className="block px-4 py-2 text-sm font-semibold text-blue-600 hover:bg-gray-100"
-                                                onClick={() => setCategoryOpen(false)}
+                                                onClick={() =>
+                                                    setCategoryOpen(false)
+                                                }
                                             >
                                                 More Categories...
                                             </HashLink>
@@ -128,16 +152,52 @@ function Navbar() {
                                     </NavLink>
                                 )}
                                 <span className="text-gray-300 h-6 w-px bg-gray-300"></span>
-                                <div className="text-gray-700">
-                                    Halo, <span className="font-semibold">{user.name}</span>
+                                {/* Profile Dropdown - click based */}
+                                <div className="relative" ref={profileMenuRef}>
+                                    <button
+                                        className="flex items-center gap-2 text-gray-700 font-semibold focus:outline-none"
+                                        onClick={() =>
+                                            setProfileOpen((prev) => !prev)
+                                        }
+                                    >
+                                        <CircleUser size={24} />
+                                        <span>{user.name}</span>
+                                        <ChevronDown size={18} />
+                                    </button>
+                                    {isProfileOpen && (
+                                        <div className="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-10">
+                                            {/* Only show Riwayat Pesanan for regular user */}
+                                            {user.role !== 'admin' && (
+                                                <Link
+                                                    to="/order-history"
+                                                    className="flex items-center px-4 py-2 text-gray-700 hover:bg-gray-100"
+                                                    onClick={() =>
+                                                        setProfileOpen(false)
+                                                    }
+                                                >
+                                                    <ClipboardClock
+                                                        size={18}
+                                                        className="mr-2"
+                                                    />
+                                                    Riwayat Pesanan
+                                                </Link>
+                                            )}
+                                            <button
+                                                onClick={() => {
+                                                    setProfileOpen(false);
+                                                    handleLogout();
+                                                }}
+                                                className="flex items-center w-full px-4 py-2 text-red-500 hover:bg-red-50 rounded-md"
+                                            >
+                                                <LogOut
+                                                    size={18}
+                                                    className="mr-2"
+                                                />
+                                                Logout
+                                            </button>
+                                        </div>
+                                    )}
                                 </div>
-                                <button
-                                    onClick={handleLogout}
-                                    className="flex items-center text-red-500 hover:bg-red-50 rounded-md px-3 py-2 transition-colors"
-                                >
-                                    <LogOut size={20} className="mr-2" />
-                                    <span className="font-semibold">Logout</span>
-                                </button>
                             </div>
                         ) : (
                             <div className="hidden md:flex items-center space-x-2">

--- a/frontend/src/components/ProductCard.jsx
+++ b/frontend/src/components/ProductCard.jsx
@@ -1,24 +1,27 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { ShoppingCart } from 'lucide-react';
+
+import StarRating from './StarRating';
 
 function ProductCard({ product, onAddToCart }) {
     let imageUrl = '';
     if (product.primary_image && product.primary_image.image_path) {
-        // If image_path already starts with /storage or /public, use as is, else prepend
-        if (product.primary_image.image_path.startsWith('http')) {
-            imageUrl = product.primary_image.image_path;
-        } else if (product.primary_image.image_path.startsWith('/storage')) {
-            imageUrl = `http://localhost:8000${product.primary_image.image_path}`;
-        } else if (product.primary_image.image_path.startsWith('public/')) {
-            imageUrl = `http://localhost:8000/storage/${product.primary_image.image_path.replace(
+        const path = product.primary_image.image_path;
+        if (path.startsWith('http')) {
+            imageUrl = path;
+        } else if (path.startsWith('/storage')) {
+            imageUrl = `http://localhost:8000${path}`;
+        } else if (path.startsWith('public/')) {
+            imageUrl = `http://localhost:8000/storage/${path.replace(
                 'public/',
                 ''
             )}`;
         } else {
-            imageUrl = `/no-image.webp`;
+            imageUrl = '/no-image.webp';
         }
     } else {
-        imageUrl = `/no-image.webp`;
+        imageUrl = '/no-image.webp';
     }
 
     const handleAddToCart = (e) => {
@@ -65,7 +68,31 @@ function ProductCard({ product, onAddToCart }) {
                                 product.price
                             )}
                         </div>
+
+                        {/* Rating, review count, sold count */}
+                        <div className="flex items-center justify-center gap-3 mt-2">
+                            <StarRating
+                                rating={Math.round(
+                                    product.reviews_avg_rating || 0
+                                )}
+                            />
+                            <span className="text-sm text-yellow-200">
+                                ({product.reviews_count || 0})
+                            </span>
+                            <span className="text-xs text-gray-200 ml-2">
+                                Terjual: {product.order_items_count || 0}
+                            </span>
+                        </div>
                     </div>
+
+                    {/* Quick Add to Cart */}
+                    <button
+                        className="absolute top-4 right-4 bg-yellow-400 hover:bg-yellow-500 text-white rounded-full p-2 shadow-lg"
+                        onClick={handleAddToCart}
+                        aria-label="Tambah ke Keranjang"
+                    >
+                        <ShoppingCart size={22} />
+                    </button>
                 </div>
             </div>
         </Link>

--- a/frontend/src/components/ReviewForm.jsx
+++ b/frontend/src/components/ReviewForm.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import StarRating from './StarRating';
+import axiosClient from '../api/axiosClient';
+
+/**
+ * ReviewForm modal
+ * Props:
+ * - productId
+ * - orderItemId
+ * - onSuccess (callback after submit)
+ * - onClose (close modal)
+ */
+const ReviewForm = ({ productId, orderItemId, onSuccess, onClose }) => {
+    const [rating, setRating] = useState(0);
+    const [comment, setComment] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError('');
+        try {
+            const res = await axiosClient.post('/reviews', {
+                product_id: productId,
+                order_item_id: orderItemId,
+                rating,
+                comment,
+            });
+            if (onSuccess) onSuccess(res.data);
+            if (onClose) onClose();
+        } catch (err) {
+            setError(err.response?.data?.message || err.message || 'Gagal submit review');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+            <form
+                className="bg-white rounded-lg shadow-lg p-6 w-full max-w-md"
+                onSubmit={handleSubmit}
+            >
+                <h2 className="text-lg font-bold mb-4">Tulis Review</h2>
+                <label className="block mb-2">Rating:</label>
+                <StarRating
+                    rating={rating}
+                    readOnly={false}
+                    onRate={setRating}
+                />
+                <label className="block mt-4 mb-2">Komentar:</label>
+                <textarea
+                    className="w-full border rounded p-2"
+                    rows={3}
+                    value={comment}
+                    onChange={(e) => setComment(e.target.value)}
+                    placeholder="Tulis komentar..."
+                />
+                {error && <div className="text-red-500 mt-2">{error}</div>}
+                <div className="flex gap-2 mt-6">
+                    <button
+                        type="submit"
+                        className="bg-yellow-400 text-white px-4 py-2 rounded hover:bg-yellow-500"
+                        disabled={loading || rating === 0}
+                    >
+                        {loading ? 'Mengirim...' : 'Kirim Review'}
+                    </button>
+                    <button
+                        type="button"
+                        className="bg-gray-200 px-4 py-2 rounded"
+                        onClick={onClose}
+                        disabled={loading}
+                    >
+                        Batal
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+};
+
+export default ReviewForm;

--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -41,8 +41,16 @@ function SearchBar() {
     const fetchSuggestions = async () => {
         setLoading(true);
         try {
-            const response = await axiosClient.get(`/products?search=${query}`);
-            setSuggestions(response.data.data || response.data);
+            // Ambil semua produk yang cocok, non-paginated, limit 10
+            const response = await axiosClient.get(
+                `/products?search=${query}&limit=10&all=1`
+            );
+            // Cek jika response.data.data adalah paginated, ambil .data
+            let arr =
+                response.data?.data?.data ||
+                response.data?.data ||
+                response.data;
+            setSuggestions(Array.isArray(arr) ? arr : []);
         } catch (error) {
             console.error('Error fetching search suggestions:', error);
             setSuggestions([]);

--- a/frontend/src/components/SearchOrderBar.jsx
+++ b/frontend/src/components/SearchOrderBar.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+const SearchOrderBar = ({ onSearch }) => {
+    const [query, setQuery] = useState('');
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        onSearch(query.trim());
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="flex items-center gap-2 mb-6">
+            <input
+                type="text"
+                className="border rounded px-3 py-2 w-full"
+                placeholder="Cari produk atau No. Invoice..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+            />
+            <button
+                type="submit"
+                className="bg-[#1B263B] text-white px-4 py-2 rounded hover:bg-[#23304a]"
+            >
+                Cari
+            </button>
+        </form>
+    );
+};
+
+export default SearchOrderBar;

--- a/frontend/src/components/StarRating.jsx
+++ b/frontend/src/components/StarRating.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Star } from 'lucide-react';
+
+/**
+ * StarRating component
+ * @param {number} rating - current rating (1-5)
+ * @param {number} max - max stars (default 5)
+ * @param {function} onRate - optional callback for interactive rating
+ * @param {boolean} readOnly - if true, stars are not clickable
+ */
+const StarRating = ({ rating = 0, max = 5, onRate, readOnly = true }) => {
+    return (
+        <div style={{ display: 'flex', gap: 2 }}>
+            {Array.from({ length: max }).map((_, i) => (
+                <Star
+                    key={i}
+                    size={20}
+                    color={i < rating ? '#facc15' : '#d1d5db'} // gold for filled, gray for empty
+                    fill={i < rating ? '#facc15' : 'none'}
+                    style={{ cursor: readOnly ? 'default' : 'pointer' }}
+                    onClick={() => !readOnly && onRate && onRate(i + 1)}
+                    data-testid={i < rating ? 'star-filled' : 'star-empty'}
+                />
+            ))}
+        </div>
+    );
+};
+
+export default StarRating;

--- a/frontend/src/pages/CategoryPage.jsx
+++ b/frontend/src/pages/CategoryPage.jsx
@@ -14,13 +14,20 @@ function CategoryPage() {
             setLoading(true);
             try {
                 // First, get the category details to display the name
-                const categoryResponse = await axiosClient.get(`/categories/${categoryId}`);
+                const categoryResponse = await axiosClient.get(
+                    `/categories/${categoryId}`
+                );
                 setCategory(categoryResponse.data);
 
                 // Then, get the products for that category
-                const productsResponse = await axiosClient.get(`/products?category_id=${categoryId}`);
-                setProducts(productsResponse.data);
-                
+                const productsResponse = await axiosClient.get(
+                    `/products?category_id=${categoryId}&limit=100&all=1`
+                );
+                let arr =
+                    productsResponse.data?.data?.data ||
+                    productsResponse.data?.data ||
+                    productsResponse.data;
+                setProducts(Array.isArray(arr) ? arr : []);
                 setError(null);
             } catch (err) {
                 setError('Failed to fetch products for this category.');
@@ -39,14 +46,18 @@ function CategoryPage() {
             {error && <p className="text-center text-red-500">{error}</p>}
             {!loading && !error && category && (
                 <>
-                    <h1 className="text-3xl font-bold mb-6 text-center">{category.name}</h1>
+                    <h1 className="text-3xl font-bold mb-6 text-center">
+                        {category.name}
+                    </h1>
                     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                         {products.map((product) => (
                             <ProductCard key={product.id} product={product} />
                         ))}
                     </div>
                     {products.length === 0 && (
-                        <p className="text-center text-gray-500">No products found in this category.</p>
+                        <p className="text-center text-gray-500">
+                            No products found in this category.
+                        </p>
                     )}
                 </>
             )}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -22,12 +22,23 @@ export default function HomePage() {
         const fetchHomePageData = async () => {
             try {
                 setLoading(true);
-                const [productsResponse, categoriesResponse] = await Promise.all([
-                    axiosClient.get('/products'),
-                    axiosClient.get('/categories')
-                ]);
-                setProducts(productsResponse.data);
-                setCategories(categoriesResponse.data);
+                const [productsResponse, categoriesResponse] =
+                    await Promise.all([
+                        axiosClient.get('/products'),
+                        axiosClient.get('/categories'),
+                    ]);
+                // Ambil array produk dari berbagai kemungkinan struktur response
+                let arr =
+                    productsResponse.data?.data?.data ||
+                    productsResponse.data?.data ||
+                    productsResponse.data ||
+                    [];
+                setProducts(Array.isArray(arr) ? arr : []);
+                setCategories(
+                    Array.isArray(categoriesResponse.data)
+                        ? categoriesResponse.data
+                        : categoriesResponse.data.data || []
+                );
                 setError(null);
             } catch (err) {
                 let msg = 'Terjadi kesalahan yang tidak diketahui.';
@@ -57,18 +68,19 @@ export default function HomePage() {
                 <BannerSlider height={`calc(80vh)`} />
             </section>
 
-            <section id="all-categories" className="mb-8 mt-6 flex flex-wrap gap-4 justify-center">
+            <section
+                id="all-categories"
+                className="mb-8 mt-6 flex flex-wrap gap-4 justify-center"
+            >
                 {/* Static "All Categories" Button */}
                 <Link to="/">
-                    <button
-                        className="px-5 py-2 rounded-full text-base font-semibold text-white bg-[#0D1B2A] transition-transform transform hover:scale-105 shadow-md"
-                    >
+                    <button className="px-5 py-2 rounded-full text-base font-semibold text-white bg-[#0D1B2A] transition-transform transform hover:scale-105 shadow-md">
                         All Categories
                     </button>
                 </Link>
 
                 {/* Dynamic Category Buttons */}
-                {categories.map((cat) => (
+                {(Array.isArray(categories) ? categories : []).map((cat) => (
                     <Link key={cat.id} to={`/category/${cat.id}`}>
                         <button className="px-5 py-2 rounded-full text-base font-medium text-white bg-[#415A77] hover:bg-[#1B263B] transition-colors shadow-sm">
                             {cat.name}
@@ -84,7 +96,11 @@ export default function HomePage() {
                         Error: {error}
                     </p>
                 )}
-                {!loading && !error && <ProductList products={products} />}
+                {!loading && !error && (
+                    <ProductList
+                        products={Array.isArray(products) ? products : []}
+                    />
+                )}
             </section>
         </div>
     );

--- a/frontend/src/pages/OrderHistoryPage.jsx
+++ b/frontend/src/pages/OrderHistoryPage.jsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import ReviewForm from '../components/ReviewForm';
+import StarRating from '../components/StarRating';
+import axiosClient from '../api/axiosClient';
+import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
+import SearchOrderBar from '../components/SearchOrderBar';
+import { useNavigate } from 'react-router-dom';
+
+const OrderHistoryPage = () => {
+    const [orders, setOrders] = useState([]);
+    const [filteredOrders, setFilteredOrders] = useState([]);
+    const [selectedItem, setSelectedItem] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const fetchOrders = async () => {
+            setLoading(true);
+            try {
+                const res = await axiosClient.get('/orders');
+                setOrders(res.data.data || []);
+                setFilteredOrders(res.data.data || []);
+            } catch (err) {
+                setError(err.response?.data?.message || err.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchOrders();
+    }, []);
+
+    const handleReviewSuccess = (review) => {
+        setSelectedItem(null);
+        window.location.reload();
+    };
+
+    const handleSearch = (query) => {
+        if (!query) {
+            setFilteredOrders(orders);
+            return;
+        }
+        const lowerQuery = query.toLowerCase();
+        setFilteredOrders(
+            orders.filter(
+                (order) =>
+                    order.order_number.toLowerCase().includes(lowerQuery) ||
+                    order.items.some((item) =>
+                        item.product_name.toLowerCase().includes(lowerQuery)
+                    )
+            )
+        );
+    };
+
+    return (
+        <>
+            <Navbar />
+            <div className="max-w-3xl mx-auto py-8 px-4 min-h-[70vh]">
+                <h1 className="text-2xl font-bold mb-6">Riwayat Pesanan</h1>
+                <SearchOrderBar onSearch={handleSearch} />
+                <button
+                    className="mb-6 bg-gray-100 text-[#1B263B] px-4 py-2 rounded hover:bg-gray-200 font-semibold"
+                    onClick={() => navigate('/')}
+                >
+                    Kembali ke Homepage
+                </button>
+                {loading && <div>Memuat...</div>}
+                {error && <div className="text-red-500">{error}</div>}
+                {filteredOrders.length === 0 && !loading && (
+                    <div>Tidak ada pesanan.</div>
+                )}
+                {filteredOrders.map((order) => (
+                    <div
+                        key={order.id}
+                        className="border rounded-lg mb-6 p-4 bg-white shadow"
+                    >
+                        <div className="font-semibold mb-2">
+                            No. Invoice: {order.order_number}
+                        </div>
+                        <div className="mb-2">Status: {order.status}</div>
+                        <div className="mb-2">Total: Rp{order.total}</div>
+                        <div className="mb-2">Alamat: {order.address_text}</div>
+                        <div className="mt-4">
+                            <div className="font-semibold mb-2">Produk:</div>
+                            {order.items.map((item) => (
+                                <div
+                                    key={item.id}
+                                    className="flex items-center gap-4 border-b py-2"
+                                >
+                                    <div className="flex-1">
+                                        <div className="font-medium">
+                                            {item.product_name}
+                                        </div>
+                                        <div>Qty: {item.quantity}</div>
+                                        <div>Harga: Rp{item.price}</div>
+                                    </div>
+                                    {item.review ? (
+                                        <div className="flex flex-col items-end">
+                                            <span className="text-xs text-gray-500 mb-1">
+                                                Review Terkirim
+                                            </span>
+                                            <StarRating
+                                                rating={item.review.rating}
+                                            />
+                                        </div>
+                                    ) : (
+                                        <button
+                                            className="bg-yellow-400 text-white px-3 py-1 rounded hover:bg-yellow-500"
+                                            onClick={() =>
+                                                setSelectedItem({
+                                                    productId: item.product_id,
+                                                    orderItemId: item.id,
+                                                })
+                                            }
+                                        >
+                                            Tulis Review
+                                        </button>
+                                    )}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                ))}
+                {selectedItem && (
+                    <ReviewForm
+                        productId={selectedItem.productId}
+                        orderItemId={selectedItem.orderItemId}
+                        onSuccess={handleReviewSuccess}
+                        onClose={() => setSelectedItem(null)}
+                    />
+                )}
+            </div>
+            <Footer />
+        </>
+    );
+};
+
+export default OrderHistoryPage;

--- a/frontend/src/pages/SearchResultsPage.jsx
+++ b/frontend/src/pages/SearchResultsPage.jsx
@@ -20,10 +20,15 @@ function SearchResultsPage() {
         const fetchSearchResults = async () => {
             setLoading(true);
             try {
+                // Ambil semua produk yang cocok, non-paginated
                 const response = await axiosClient.get(
-                    `/products?search=${query}`
+                    `/products?search=${query}&limit=100&all=1`
                 );
-                setSearchResults(response.data.data || response.data);
+                let arr =
+                    response.data?.data?.data ||
+                    response.data?.data ||
+                    response.data;
+                setSearchResults(Array.isArray(arr) ? arr : []);
                 setError(null);
             } catch (err) {
                 setError('Gagal memuat hasil pencarian.');


### PR DESCRIPTION
This commit introduces the foundational functionality for the user's order history page.

-   Creates a new route and page at `/order-history` for authenticated users.
-   Fetches and displays a list of the user's past orders and their associated items.
-   Adds a placeholder "Leave a Review" button for each purchased item, preparing for the upcoming review submission feature.

The next steps will involve implementing the review modal and adding status filtering (e.g., Processing, Shipped, Completed).