### PR TITLE
feat(sanctum): configure token expiration and schedule pruning

### DIFF
--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    /**
+     * Define the application's command schedule.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @return void
+     */
+    protected function schedule(Schedule $schedule)
+    {
+        $schedule->command('sanctum:prune-expired')->daily();
+    }
+
+    /**
+     * Register the commands for the application.
+     *
+     * @return void
+     */
+    protected function commands()
+    {
+        $this->load(__DIR__.'/Commands');
+
+        require base_path('routes/console.php');
+    }
+}

--- a/backend/config/sanctum.php
+++ b/backend/config/sanctum.php
@@ -47,7 +47,7 @@ return [
     |
     */
 
-    'expiration' => null,
+    'expiration' => 120, // 2 hours time for session tokens
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
- Sets the personal access token lifetime to 120 minutes in the sanctum.php config file, ensuring all new tokens automatically expire after 2 hours to enhance security.
- Schedules the sanctum:prune-expired command to run daily within app/Console/Kernel.php, automating the cleanup of expired tokens from the database.